### PR TITLE
fix(runtime): show headless agent progress during execution

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-06-headless-progress-follows-session-leases.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-06-headless-progress-follows-session-leases.md
@@ -1,0 +1,23 @@
+# Agent Note: Headless progress follows session leases
+
+Status: implemented
+
+## Problem
+
+Headless commands can run for minutes while their binding reports idle. A browser-local thinking timer cannot recover actual execution state after a refresh. Execution batches and lease recovery also make a single command's completion insufficient to declare the whole agent idle.
+
+## Decision
+
+Session lifecycle is the authority for headless binding progress. A database projection updates eligible idle/running bindings when a session enters or leaves active state, aggregating all sessions for the agent after acquiring its binding lock. Paused, disabled and error states retain their administrative meaning. Unchanged progress emits no extra binding update. The existing [binding sync path](../../feature/2026-09-03-runtime-bindings-in-the-sync-path.md) delivers changes and refresh snapshots.
+
+Retry scheduling releases the session in the same attempt-fenced transaction when no active batch members remain. Result commit has one fenced release owner, with no later unfenced draining write. The successor migration reconciles existing leased work and inactive retry sessions. `in_flight_turn_id` is not synthesized: an agent's batch can own several turns, while running/idle is an aggregate state.
+
+## Alternatives considered
+
+- **Write state separately in each driver or executor:** rejected because local batch, remote claim, retry and expiry paths would become independent state machines.
+- **Trigger on both commands and sessions:** rejected because command updates can precede session updates; taking the binding lock between them creates a binding/session lock inversion. Session-only projection preserves one lifecycle owner.
+- **Use only the front-end thinking timer:** rejected because it cannot survive refresh or distinguish a long operation from a hung lease.
+
+## Consequences
+
+The change covers headless progress for every driver sharing the session store, without changing PTY byte transport or interpreting CLI output. A successful command remains running until its result is committed; retry backoff is idle. Real PostgreSQL regressions cover batch completion, retry, expiry, stale attempts, remote success/failure, protected states and list/detail/bootstrap/sync agreement. Runtime progress emits the existing sync changes; it is not a human administrative action in the audit log.

--- a/apps/web/tests/e2e/agent.spec.ts
+++ b/apps/web/tests/e2e/agent.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { mkdir, writeFile, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { postgresQueryClient } from "../../lib/groups/group-provisioning-db";
 import { API_BASE, login, signup, gotoDashboard } from "../fixtures/auth";
 import {
   getConsoleSnapshot,
@@ -11,6 +12,41 @@ import {
   createCompany,
   deleteCompany,
 } from "../fixtures/api";
+
+test("headless binding progress reaches the group details and survives reload", async ({ page }) => {
+  const { token, principal } = await signup(page, uniqueName("progress-user"), "progress-test-password");
+  const company = await createCompany(page, token, principal.id, uniqueName("progress-company"));
+  const db = await postgresQueryClient();
+  const sessionKey = uniqueName("progress-session");
+  try {
+    const agent = await provisionAgent(page, token, uniqueName("progress-agent"), { workspaceId: company.id });
+    const group = await createGroup(page, token, principal.id, uniqueName("progress-group"), [agent.agentId], company.id);
+    // Replace only the executor lease for deterministic timing. The DB projection,
+    // sync feed, authenticated binding reads and browser rendering stay real;
+    // gateway integration tests exercise the production lease methods themselves.
+    await db.query("INSERT INTO session_registry (session_key, agent_id, conversation_id) VALUES ($1, $2, $3)", [sessionKey, agent.agentId, group.id]);
+    const openDetails = async () => {
+      await gotoDashboard(page);
+      await page.locator(".company-selector-btn").click();
+      await page.locator(".company-dropdown-item-name").filter({ hasText: company.name }).click();
+      await page.locator(`[data-conversation-id="${group.id}"]`).click();
+      await page.getByTitle("Toggle details", { exact: true }).click();
+      await page.locator(".member-row-main").filter({ hasText: agent.agentName }).click();
+    };
+    await openDetails();
+    await expect(page.locator(".member-row-state")).toHaveText("idle");
+    await db.query("UPDATE session_registry SET status = 'active', epoch = epoch + 1 WHERE session_key = $1", [sessionKey]);
+    await expect(page.locator(".member-row-state")).toHaveText("running");
+    await page.reload();
+    await openDetails();
+    await expect(page.locator(".member-row-state")).toHaveText("running");
+    await db.query("UPDATE session_registry SET status = 'idle' WHERE session_key = $1", [sessionKey]);
+    await expect(page.locator(".member-row-state")).toHaveText("idle");
+  } finally {
+    await db.query("DELETE FROM session_registry WHERE session_key = $1", [sessionKey]);
+    await deleteCompany(page, token, company.id);
+  }
+});
 
 for (const scenario of ["reports load and delete failures", "keeps skill content with its selected title", "keeps loading until the selected skill returns", "browses and imports a Markdown file"] as const) {
   test(`Skills ${scenario}`, async ({ page }, testInfo) => {

--- a/crates/choruz-session/src/store.rs
+++ b/crates/choruz-session/src/store.rs
@@ -493,13 +493,14 @@ impl PgSessionStore {
         update: &CommandStatusUpdate,
         expected_attempt_id: Option<&str>,
     ) -> SessionResult<()> {
-        let client = self.connect().await?;
+        let mut client = self.connect().await?;
+        let tx = client.transaction().await?;
         let now = Utc::now();
         let status_str = update.status.as_str().to_string();
         let expected_attempt_id = expected_attempt_id.map(str::to_owned);
 
-        let affected = client
-            .execute(
+        let row = tx
+            .query_opt(
                 "UPDATE agent_commands
                  SET status = $2,
                      current_attempt_id = COALESCE($3, current_attempt_id),
@@ -517,7 +518,7 @@ impl PgSessionStore {
                                WHERE session_key = agent_commands.session_key
                            )
                        )
-                   )",
+                   ) RETURNING session_key, current_epoch",
                 &[
                     &update.command_id,
                     &status_str,
@@ -532,7 +533,7 @@ impl PgSessionStore {
                 ],
             )
             .await?;
-        if affected == 0 {
+        let Some(row) = row else {
             return match expected_attempt_id {
                 Some(attempt_id) => Err(SessionError::StaleAttempt {
                     command_id: update.command_id.clone(),
@@ -540,7 +541,16 @@ impl PgSessionStore {
                 }),
                 None => Err(SessionError::CommandNotFound(update.command_id.clone())),
             };
+        };
+        if matches!(
+            update.status,
+            CommandStatus::RetryScheduled | CommandStatus::DeadLetter | CommandStatus::Committed
+        ) {
+            let session_key: String = row.get("session_key");
+            let epoch: Option<i32> = row.get("current_epoch");
+            release_session_if_no_active_commands(&tx, &session_key, epoch, now).await?;
         }
+        tx.commit().await?;
         Ok(())
     }
 

--- a/docs/subsystems/agent-runtime.md
+++ b/docs/subsystems/agent-runtime.md
@@ -89,12 +89,14 @@ Headless path: the pipeline's `spawn_headless_session` resolves the active bindi
 
 ## Invariants
 
+Headless binding progress follows active session leases across the agent's conversations. Local and remote execution project `running`; final batch completion, retry backoff and lease expiry project `idle`. Paused, disabled and error bindings are not overwritten. Bootstrap and binding sync updates expose the same stored state. `in_flight_turn_id` does not represent a multi-turn batch. See the [progress ownership decision](../../.agents/notes/implemented/bug-fix/2026-09-06-headless-progress-follows-session-leases.md).
+
 | Invariant | Pinned by |
 |---|---|
 | One non-disabled binding per agent (`agent_runtime_bindings_one_per_agent` partial unique index); a second create returns the existing one | `binding_defaults_and_uniqueness_are_enforced`, `binding_creation_waits_for_disable_and_rejects_the_disabled_agent` in [`crates/choruz-agent-runtime/tests/runtime_store.rs`](../../crates/choruz-agent-runtime/tests/runtime_store.rs) |
 | Disabling an agent's bindings is atomic and idempotent | `disabling_agent_bindings_is_atomic_and_idempotent` |
 | `workspace_path` is normalised and guarded; state transitions follow `can_transition_to` | `workspace_paths_are_normalized_and_guarded`, `state_transitions_are_guarded` |
-| Binding state changes and rebinds write `audit_log` entries | `state_changes_and_rebind_write_audit_entries` |
+| Administrative binding state changes and rebinds write `audit_log` entries; automatic headless progress uses the sync feed | `state_changes_and_rebind_write_audit_entries`, `headless_progress_tracks_leases_in_binding_snapshots_and_sync` |
 | A terminal session anchor is accepted only for the binding generation that captured it and only for the same workspace | `terminal_session_anchor_preserves_unrelated_config_and_validates_binding`, `terminal_session_anchor_rejects_delayed_capture_after_reset_touch`, `codex_terminal_anchor_rejects_same_native_session_for_same_workspace_binding` |
 | Terminal routes never write `conversation_events`; terminal bytes bypass the pipeline | `terminal_routes_do_not_write_conversation_events` in [`services/choruz-api-gateway/src/tests/runtime.rs`](../../services/choruz-api-gateway/src/tests/runtime.rs) |
 | A binding may reference only an `active` harness account of the same company, driver and host, and only a model listed in `models_json`; the trigger stamps `harness_account_name` and `harness_account_profile_kind` | `validate_runtime_binding_harness_account` (V035); `harness_account_binding_trigger_rejects_unverified_models` |

--- a/migrations/V049__headless_binding_progress.sql
+++ b/migrations/V049__headless_binding_progress.sql
@@ -1,0 +1,60 @@
+-- Execution leases own headless progress; bindings expose it through the
+-- existing bootstrap and sync feed, not a second executor state machine.
+CREATE OR REPLACE FUNCTION refresh_headless_binding_progress(target_agent TEXT) RETURNS VOID AS $$
+DECLARE
+    binding_id TEXT;
+    is_active BOOLEAN;
+BEGIN
+    -- Serialize the aggregate read after the binding lock. A different
+    -- conversation finishing must not erase this agent's newly leased work.
+    SELECT id INTO binding_id FROM agent_runtime_bindings
+    WHERE agent_principal_id = target_agent AND state IN ('idle', 'running')
+    FOR UPDATE;
+    IF binding_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    SELECT EXISTS (SELECT 1 FROM session_registry
+        WHERE agent_id = target_agent AND status = 'active') INTO is_active;
+
+    UPDATE agent_runtime_bindings
+    SET state = CASE WHEN is_active THEN 'running' ELSE 'idle' END,
+        updated_at = NOW()
+    WHERE id = binding_id
+        AND state IS DISTINCT FROM CASE WHEN is_active THEN 'running' ELSE 'idle' END;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION sync_headless_binding_progress() RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM refresh_headless_binding_progress(NEW.agent_id);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER headless_session_progress
+    AFTER UPDATE OF status, epoch ON session_registry
+    FOR EACH ROW
+    WHEN (OLD.status = 'active' OR NEW.status = 'active')
+    EXECUTE FUNCTION sync_headless_binding_progress();
+
+-- Reconcile work already leased when this migration is applied.
+UPDATE session_registry s SET status = 'idle', executor_node_id = NULL,
+    last_heartbeat_at = NULL, updated_at = NOW()
+WHERE s.status = 'active' AND NOT EXISTS (
+    SELECT 1 FROM agent_commands c WHERE c.session_key = s.session_key
+        AND c.current_epoch = s.epoch
+        AND c.status IN ('leased', 'started', 'heartbeating', 'succeeded')
+);
+
+DO $$
+DECLARE
+    agent TEXT;
+BEGIN
+    FOR agent IN SELECT DISTINCT agent_id FROM session_registry
+        WHERE status = 'active'
+    LOOP
+        PERFORM refresh_headless_binding_progress(agent);
+    END LOOP;
+END;
+$$;

--- a/services/choruz-api-gateway/src/tests/runtime.rs
+++ b/services/choruz-api-gateway/src/tests/runtime.rs
@@ -1,6 +1,479 @@
 use super::*;
 
 #[tokio::test]
+async fn headless_progress_tracks_leases_in_binding_snapshots_and_sync() {
+    use choruz_session::{CommandStatus, CommandStatusUpdate, InsertCommand, PgSessionStore};
+
+    let database = TestDatabase::create_without_migrations().await;
+    database
+        .apply_migrations_through("V048__online_groups.sql")
+        .await;
+    let runtime = RuntimeStore::new(database.database_url.clone());
+    let store = PgSessionStore::new(&database.database_url);
+    let app = choruz_application::ChatApp::new();
+    let operator = LocalAuthConfig::from_env()
+        .ensure_operator_sync(&app)
+        .unwrap();
+    let agent = app
+        .create_agent(CreateAgentRequest {
+            actor_id: operator.id.clone(),
+            name: "Headless progress".into(),
+            scopes: vec!["messages:read".into(), "messages:write".into()],
+            workspace_id: None,
+            channel_visibility: None,
+        })
+        .unwrap();
+    let conversation = app
+        .create_direct_conversation(CreateDirectConversationRequest {
+            actor_id: operator.id.clone(),
+            peer_principal_id: agent.principal.id.clone(),
+            workspace_id: None,
+        })
+        .unwrap();
+    seed_principal_to_db(&database.database_url, &operator).await;
+    seed_principal_to_db(&database.database_url, &agent.principal).await;
+    seed_conversation_to_db(&database.database_url, &conversation).await;
+    let binding = runtime
+        .create_binding(CreateBindingInput {
+            conversation_id: conversation.id.clone(),
+            agent_principal_id: agent.principal.id.clone(),
+            driver_type: DriverType::ClaudeTerminal,
+            workspace_path: "/worktrees/progress".into(),
+            git_worktree_path: None,
+            config_json: json!({}),
+            audit_actor: Some(audit_actor(&operator)),
+        })
+        .await
+        .unwrap();
+    let router = runtime_router_with_db(app, runtime.clone(), &database.database_url);
+    let client = store.connect().await.unwrap();
+    let session = Uuid::now_v7().to_string();
+    store
+        .upsert_session(&session, &agent.principal.id, &conversation.id)
+        .await
+        .unwrap();
+    let input = || InsertCommand {
+        command_id: Uuid::now_v7().to_string(),
+        route_id: Uuid::now_v7().to_string(),
+        session_key: session.clone(),
+        agent_id: agent.principal.id.clone(),
+        conversation_id: conversation.id.clone(),
+        message_id: Uuid::now_v7().to_string(),
+        turn_id: Uuid::now_v7().to_string(),
+        prompt: "Work until released".into(),
+        max_attempts: 3,
+        metadata: json!({}),
+    };
+    let first = store.insert_command(&input()).await.unwrap();
+    let second = store.insert_command(&input()).await.unwrap();
+    let (_, before) = api_json_request(
+        router.clone(),
+        &operator,
+        Method::GET,
+        "/v1/bootstrap?limit=10".into(),
+    )
+    .await;
+    let cursor = before["sync_cursor"].as_u64().unwrap();
+    let leases = store
+        .assign_batch_leases(
+            &[first.command_id.clone(), second.command_id.clone()],
+            "test-executor",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        runtime.get_binding(&binding.id).await.unwrap().state,
+        BindingState::Idle,
+        "the pre-migration database reproduces the reported idle binding"
+    );
+    let backoff_session = Uuid::now_v7().to_string();
+    store
+        .upsert_session(&backoff_session, &agent.principal.id, &conversation.id)
+        .await
+        .unwrap();
+    client
+        .execute(
+            "UPDATE session_registry SET status = 'active' WHERE session_key = $1",
+            &[&backoff_session],
+        )
+        .await
+        .unwrap();
+    apply_migration_files(&client, |name| name.starts_with("V049__")).await;
+    assert_eq!(
+        store
+            .get_session(&backoff_session)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        choruz_session::SessionStatus::Idle,
+        "upgrade clears a stranded pre-fix session with no active command"
+    );
+
+    let row = client
+        .query_one(
+            "SELECT state, in_flight_turn_id FROM agent_runtime_bindings WHERE id = $1",
+            &[&binding.id],
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        row.get::<_, String>("state"),
+        "running",
+        "a real batch lease must persist binding progress"
+    );
+    for path in [
+        "/v1/runtime/bindings".to_string(),
+        format!("/v1/runtime/bindings/{}", binding.id),
+        "/v1/bootstrap?limit=10".to_string(),
+    ] {
+        let (status, body) =
+            api_json_request(router.clone(), &operator, Method::GET, path.clone()).await;
+        assert_eq!(status, StatusCode::OK);
+        let view = if path.contains("bootstrap") {
+            &body["runtime_bindings"][0]
+        } else if body.is_array() {
+            &body[0]
+        } else {
+            &body
+        };
+        assert_eq!(view["id"], binding.id);
+        assert_eq!(
+            view["state"], "running",
+            "refresh/list/detail must agree: {path}"
+        );
+    }
+    let (_, sync) = api_json_request(
+        router.clone(),
+        &operator,
+        Method::GET,
+        format!("/v1/sync?cursor={cursor}&limit=100"),
+    )
+    .await;
+    assert!(
+        sync["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|change| change["event_type"] == "runtime_binding.updated"
+                && change["entity_id"] == binding.id)
+    );
+
+    let updated_at: String = client
+        .query_one(
+            "SELECT updated_at::text FROM agent_runtime_bindings WHERE id = $1",
+            &[&binding.id],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    let (_, snapshot) = api_json_request(
+        router.clone(),
+        &operator,
+        Method::GET,
+        "/v1/bootstrap?limit=10".into(),
+    )
+    .await;
+    let unchanged_cursor = snapshot["sync_cursor"].as_u64().unwrap();
+    client
+        .execute(
+            "UPDATE session_registry SET epoch = epoch WHERE session_key = $1",
+            &[&session],
+        )
+        .await
+        .unwrap();
+    let after_update: String = client
+        .query_one(
+            "SELECT updated_at::text FROM agent_runtime_bindings WHERE id = $1",
+            &[&binding.id],
+        )
+        .await
+        .unwrap()
+        .get(0);
+    assert_eq!(
+        updated_at, after_update,
+        "unchanged progress must not rewrite the binding"
+    );
+    let (_, unchanged_sync) = api_json_request(
+        router.clone(),
+        &operator,
+        Method::GET,
+        format!("/v1/sync?cursor={unchanged_cursor}&limit=100"),
+    )
+    .await;
+    assert!(
+        !unchanged_sync["changes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|change| change["event_type"] == "runtime_binding.updated"
+                && change["entity_id"] == binding.id),
+        "unchanged progress must not emit another binding update"
+    );
+
+    store
+        .mark_command_committed_for_attempt(
+            &first.command_id,
+            &leases[&first.command_id].attempt_id,
+        )
+        .await
+        .unwrap();
+    let row = client
+        .query_one(
+            "SELECT state, in_flight_turn_id FROM agent_runtime_bindings WHERE id = $1",
+            &[&binding.id],
+        )
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, String>("state"), "running");
+    store
+        .mark_command_committed_for_attempt(
+            &second.command_id,
+            &leases[&second.command_id].attempt_id,
+        )
+        .await
+        .unwrap();
+    let row = client
+        .query_one(
+            "SELECT state, in_flight_turn_id FROM agent_runtime_bindings WHERE id = $1",
+            &[&binding.id],
+        )
+        .await
+        .unwrap();
+    assert_eq!(row.get::<_, String>("state"), "idle");
+    assert_eq!(row.get::<_, Option<String>>("in_flight_turn_id"), None);
+
+    let retry = store.insert_command(&input()).await.unwrap();
+    let old_lease = store
+        .assign_lease(&retry.command_id, "test-executor")
+        .await
+        .unwrap();
+    let expired = store
+        .check_expired_leases(chrono::Utc::now() + chrono::TimeDelta::seconds(121), 120)
+        .await
+        .unwrap();
+    store
+        .handle_lease_expiry(
+            expired
+                .iter()
+                .find(|e| e.command_id == retry.command_id)
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime.get_binding(&binding.id).await.unwrap().state,
+        BindingState::Idle
+    );
+    store
+        .update_command_status(&CommandStatusUpdate {
+            command_id: retry.command_id.clone(),
+            status: CommandStatus::Pending,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let fresh_lease = store
+        .assign_lease(&retry.command_id, "replacement-executor")
+        .await
+        .unwrap();
+    assert!(
+        store
+            .mark_command_committed_for_attempt(&retry.command_id, &old_lease.attempt_id)
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        runtime.get_binding(&binding.id).await.unwrap().state,
+        BindingState::Running
+    );
+    store
+        .dead_letter_command_for_attempt(
+            &choruz_session::InsertDeadLetter {
+                source_type: "command".into(),
+                source_id: retry.command_id.clone(),
+                payload: json!({}),
+                error: "test execution failed".into(),
+                attempt_count: 2,
+            },
+            &fresh_lease.attempt_id,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime.get_binding(&binding.id).await.unwrap().state,
+        BindingState::Idle
+    );
+
+    let retry = store.insert_command(&input()).await.unwrap();
+    let lease = store
+        .assign_lease(&retry.command_id, "test-executor")
+        .await
+        .unwrap();
+    store
+        .update_command_status_for_attempt(
+            &CommandStatusUpdate {
+                command_id: retry.command_id.clone(),
+                status: CommandStatus::RetryScheduled,
+                next_retry_at: Some(Some(chrono::Utc::now() + chrono::TimeDelta::minutes(5))),
+                ..Default::default()
+            },
+            &lease.attempt_id,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime.get_binding(&binding.id).await.unwrap().state,
+        BindingState::Idle,
+        "backoff is not active execution even before the retry becomes due"
+    );
+
+    let host = Uuid::now_v7().to_string();
+    client.execute("UPDATE agent_runtime_bindings SET config_json = jsonb_build_object('runtime_host_id', $2::text) WHERE id = $1", &[&binding.id, &host]).await.unwrap();
+    for success in [true, false] {
+        let remote = store.insert_command(&input()).await.unwrap();
+        let (claimed, lease) = store
+            .claim_runtime_host_command(&host)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(claimed.command_id, remote.command_id);
+        assert_eq!(
+            runtime.get_binding(&binding.id).await.unwrap().state,
+            BindingState::Running
+        );
+        store
+            .complete_runtime_host_command(
+                &host,
+                "Test device",
+                &remote.command_id,
+                &lease.attempt_id,
+                success,
+                &[],
+                if success { None } else { Some("test failure") },
+                0,
+                1,
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            runtime.get_binding(&binding.id).await.unwrap().state,
+            BindingState::Idle
+        );
+    }
+    client
+        .execute(
+            "UPDATE agent_runtime_bindings SET config_json = '{}' WHERE id = $1",
+            &[&binding.id],
+        )
+        .await
+        .unwrap();
+
+    // Two conversations can contend on the shared binding. Hold its row lock
+    // until both production transitions are waiting, then verify the aggregate.
+    let other_session = Uuid::now_v7().to_string();
+    store
+        .upsert_session(&other_session, &agent.principal.id, &conversation.id)
+        .await
+        .unwrap();
+    let finishing = store.insert_command(&input()).await.unwrap();
+    let finishing_lease = store
+        .assign_lease(&finishing.command_id, "test-executor")
+        .await
+        .unwrap();
+    let mut other_input = input();
+    other_input.session_key = other_session;
+    let starting = store.insert_command(&other_input).await.unwrap();
+    let mut guard_client = store.connect().await.unwrap();
+    let guard = guard_client.transaction().await.unwrap();
+    guard
+        .query_one(
+            "SELECT id FROM agent_runtime_bindings WHERE id = $1 FOR UPDATE",
+            &[&binding.id],
+        )
+        .await
+        .unwrap();
+    let finish_name = format!("progress-finish-{}", Uuid::now_v7());
+    let start_name = format!("progress-start-{}", Uuid::now_v7());
+    let finish_store = PgSessionStore::new(&format!(
+        "{} application_name={finish_name}",
+        database.database_url
+    ));
+    let start_store = PgSessionStore::new(&format!(
+        "{} application_name={start_name}",
+        database.database_url
+    ));
+    let finish = tokio::spawn(async move {
+        finish_store
+            .mark_command_committed_for_attempt(&finishing.command_id, &finishing_lease.attempt_id)
+            .await
+    });
+    let starting_id = starting.command_id.clone();
+    let start = tokio::spawn(async move {
+        start_store
+            .assign_lease(&starting_id, "test-executor")
+            .await
+    });
+    let blocked = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            let count: i64 = client.query_one("SELECT COUNT(*) FROM pg_stat_activity WHERE application_name = ANY($1) AND wait_event_type = 'Lock'", &[&vec![finish_name.clone(), start_name.clone()]]).await.unwrap().get(0);
+            if count == 2 { break; }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }).await;
+    guard.commit().await.unwrap();
+    finish.await.unwrap().unwrap();
+    let starting_lease = start.await.unwrap().unwrap();
+    assert!(
+        blocked.is_ok(),
+        "both transitions must overlap at the binding row lock"
+    );
+    assert_eq!(
+        runtime.get_binding(&binding.id).await.unwrap().state,
+        BindingState::Running
+    );
+    store
+        .mark_command_committed_for_attempt(&starting.command_id, &starting_lease.attempt_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        runtime.get_binding(&binding.id).await.unwrap().state,
+        BindingState::Idle
+    );
+
+    // Administrative states are not overridden by execution progress.
+    for state in ["paused", "error", "disabled"] {
+        let command = store.insert_command(&input()).await.unwrap();
+        client
+            .execute(
+                "UPDATE agent_runtime_bindings SET state = $2 WHERE id = $1",
+                &[&binding.id, &state],
+            )
+            .await
+            .unwrap();
+        let lease = store
+            .assign_lease(&command.command_id, "test-executor")
+            .await
+            .unwrap();
+        store
+            .mark_command_committed_for_attempt(&command.command_id, &lease.attempt_id)
+            .await
+            .unwrap();
+        let row = client
+            .query_one(
+                "SELECT state FROM agent_runtime_bindings WHERE id = $1",
+                &[&binding.id],
+            )
+            .await
+            .unwrap();
+        assert_eq!(row.get::<_, String>(0), state);
+    }
+}
+
+#[tokio::test]
 async fn runtime_bindings_list_detail_and_redact_errors() {
     let database = TestDatabase::create().await;
     let runtime = RuntimeStore::new(database.database_url.clone());

--- a/services/choruz-api-gateway/src/tests/sessions_and_routes.rs
+++ b/services/choruz-api-gateway/src/tests/sessions_and_routes.rs
@@ -330,7 +330,7 @@ async fn native_session_import_runs_end_to_end_and_is_idempotent() {
         StatusCode::CONFLICT,
         "queued commands keep the old claim"
     );
-    commands
+    let lease = commands
         .assign_lease(&command.command_id, "owned-test-executor")
         .await
         .unwrap();
@@ -346,11 +346,8 @@ async fn native_session_import_runs_end_to_end_and_is_idempotent() {
         .unwrap()
         .get(0);
     assert_eq!(claimed, old_binding);
-    client
-        .execute(
-            "UPDATE agent_commands SET status = 'committed' WHERE command_id = $1",
-            &[&command.command_id],
-        )
+    commands
+        .mark_command_committed_for_attempt(&command.command_id, &lease.attempt_id)
         .await
         .unwrap();
     client

--- a/services/choruz-pipeline/src/pg_result_store.rs
+++ b/services/choruz-pipeline/src/pg_result_store.rs
@@ -2,9 +2,59 @@
 //!
 //! Bridges `choruz-writer::ResultStore` to the real `conversation_events` table.
 
-use choruz_session::{PgSessionStore, SessionStatus, SessionUpdate};
+use choruz_session::PgSessionStore;
 use choruz_store::{ConversationEvent, EventStore};
 use choruz_writer::{ResultStore, WriterError, WriterResult};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn writer_commit_keeps_the_fenced_session_release() {
+        let url = std::env::var("CHORUZ_TEST_DATABASE_URL")
+            .expect("source infra/host/setup_test_database.sh before database tests");
+        let sessions = PgSessionStore::new(&url);
+        let writer = PgResultStore::new(EventStore::new(&url), sessions.clone());
+        let session = choruz_common::new_id();
+        let agent = choruz_common::new_id();
+        let conversation = choruz_common::new_id();
+        sessions
+            .upsert_session(&session, &agent, &conversation)
+            .await
+            .unwrap();
+        let command = sessions
+            .insert_command(&choruz_session::InsertCommand {
+                command_id: choruz_common::new_id(),
+                route_id: choruz_common::new_id(),
+                session_key: session.clone(),
+                agent_id: agent,
+                conversation_id: conversation,
+                message_id: choruz_common::new_id(),
+                turn_id: choruz_common::new_id(),
+                prompt: "Owned writer lifecycle fixture".into(),
+                max_attempts: 3,
+                metadata: serde_json::json!({}),
+            })
+            .await
+            .unwrap();
+        let lease = sessions
+            .assign_lease(&command.command_id, "writer-test")
+            .await
+            .unwrap();
+        writer
+            .mark_committed(&command.command_id, &lease.attempt_id)
+            .await
+            .unwrap();
+        let final_session = sessions.get_session(&session).await.unwrap().unwrap();
+        assert_eq!(
+            final_session.status,
+            choruz_session::SessionStatus::Idle,
+            "the writer must not overwrite the atomic release with draining"
+        );
+        assert_eq!(final_session.epoch, lease.epoch);
+    }
+}
 
 /// Provides turn dedup and event insertion backed by PostgreSQL.
 #[derive(Clone)]
@@ -126,16 +176,8 @@ impl ResultStore for PgResultStore {
     }
 
     async fn mark_committed(&self, command_id: &str, attempt_id: &str) -> WriterResult<()> {
-        // 1. Get command to find session key
-        let cmd = self
-            .session_store
-            .get_command(command_id)
-            .await
-            .map_err(|e| WriterError::Internal(format!("failed to get command: {e}")))?
-            .ok_or_else(|| WriterError::Internal(format!("command not found: {command_id}")))?;
-        let session_key = cmd.session_key;
-
-        // 2. Mark command as committed and release lease
+        // The fenced transaction owns session release. A later draining write
+        // could overwrite a new lease acquired after this commit.
         self.session_store
             .mark_command_committed_for_attempt(command_id, attempt_id)
             .await
@@ -148,26 +190,6 @@ impl ResultStore for PgResultStore {
                     WriterError::Internal(format!("failed to mark command committed: {other}"))
                 }
             })?;
-
-        // 3. Check for more active commands; if none, transition to draining
-        match self
-            .session_store
-            .find_active_command_for_session(&session_key)
-            .await
-        {
-            Ok(None) => {
-                let update = SessionUpdate {
-                    session_key,
-                    status: Some(SessionStatus::Draining),
-                    executor_node_id: None,
-                    last_heartbeat_at: None,
-                };
-                if let Err(e) = self.session_store.update_session(&update).await {
-                    tracing::warn!(error = %e, "session draining update failed");
-                }
-            }
-            _ => {}
-        }
 
         Ok(())
     }


### PR DESCRIPTION
## Type

- [x] `api` / `database` — bugfix with a successor migration (`database` label)

## Summary

Addresses https://github.com/inclusionAI/Choruz/issues/2. Headless work currently owns command/session leases but leaves its binding idle. Project active session leases into the binding's existing running/idle state so the database, list/detail/bootstrap and browser sync agree, including after reload.

This public PR publishes the exact reviewed and tested patch already merged into the development repository. Public base `6366a8981d9d788fbac469a1bf1a7628b052fd24` has the same tree as the implementation base; public head `bce82ab848526600318b86ec42d03bcf0a04f844` and development merge `5d8d78b468eb3957b9059f81fe676132cab2f106` both have tree `152c4815ee09f523be3c92f7de1b761a7b138f12`. No private historical commits are imported. The implementation's complete Linux CI run `34061774201` passed; this PR will also run its own required CI.

- V049 serializes each agent's aggregate behind its binding lock, preserves paused/error/disabled states, suppresses unchanged-state updates and reconciles pre-existing leases.
- Retry/backoff releases a session in the attempt-fenced transaction. The writer no longer performs a later unfenced draining write that could overwrite a successor lease.
- All headless drivers share this lifecycle; no per-CLI state machine or PTY-output interpretation is introduced. `in_flight_turn_id` remains unchanged because one batch can contain several turns.

## Agent Note

[Headless progress follows session leases](.agents/notes/implemented/bug-fix/2026-09-06-headless-progress-follows-session-leases.md)

## Seams touched

- Interface: unchanged routes/schema; existing binding views expose the stored state.
- Persistence: V049 only; no new table, identifier or user-data column. Historical migrations are untouched.
- Authorization: existing binding/sync authorization remains authoritative; automatic lease progress is not a human administrative audit action.
- Observability: existing `runtime_binding.updated` feed; unchanged progress emits nothing.
- Testing: actual PgSessionStore lease/retry/expiry/remote claim and writer paths, authenticated API snapshots/feed, browser group-details/reload; existing agent.spec selector applies.
- Rollout: core session lifecycle, no plugin gate.
- Compatibility: no wire, bootstrap or sync version change.
- Documentation: agent-runtime subsystem and ownership note.

## Behaviour evidence

Real PostgreSQL test `headless_progress_tracks_leases_in_binding_snapshots_and_sync` applies V048, leases work, demonstrates the old idle binding, then applies V049. It covers upgrade reconciliation, batch partial/final completion, retry backoff, expiry, stale completion, remote success/failure, concurrent finish/start on separate sessions, protected administrative states, unchanged-state timestamp/feed suppression, and list/detail/bootstrap/sync agreement. Concurrent operations are synchronized on database locks, not sleeps.

`writer_commit_keeps_the_fenced_session_release` calls the real ResultStore commit. The existing native-session reclaim test now completes its fixture through the production fenced commit rather than a bare SQL status change that leaves a live lease behind.

Browser regression `headless binding progress reaches the group details and survives reload` proves idle → running → reload/running → idle. Only executor timing is substituted by an owned session-row lease; PostgreSQL triggers, API, authentication, sync, and rendered UI are real. This is not claimed as a live authenticated Claude/Codex/Pi model run, and no CLI protocol was changed.

Negative controls observed before restoring the fix:
- Without V049, a real batch lease still reports idle.
- Without transactional retry release, backoff incorrectly stays running.
- With the old writer draining update restored, committed session state is draining instead of idle.
All corresponding repaired regressions passed.

## Independent audit and simplify

Independent `gpt-5.6-terra` used choruz-pre-simplify-audit. Initial UNVERIFIED BPA-1 required evidence that unchanged progress produces no duplicate update. Added and executed real-trigger timestamp/feed assertions; re-audit PASS on base cb3d44437e072b3f2c298842d8de73e6f96d9cbc, dirty-diff SHA-256 540137a19d891e2245da0a7c05709c38bf30583574d6e1d3dfbbf3b53312a105.

Simplify reviewed the touched diff after PASS: retain one session projection and the existing fenced release helper; the redundant writer read/check/draining owner is removed. No additional abstraction or behaviour change was warranted.

Public-copy re-audit by the same independent Terra auditor: PASS. Base/head trees match the reviewed implementation, and both binary patches have SHA-256 `8ea70feb49f08d578c9c7a48742930a28c0628ebe2d0f06b85b7c6d816482590`. Rechecked simplify for the exact copy: no further changes; retain byte identity. Public-base pr-plan, formatting, notes and diff checks were rerun; runtime evidence belongs to this identical source tree.

## Ran locally

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`: passed on the final diff (848 Rust tests), using the repository temporary-database setup with mandatory DB tests.
- `pnpm web:check`, `pnpm web:build`: passed.
- `pnpm db:migration:smoke`, `pnpm api:smoke`: passed, including repeated schema reset/setup.
- Selected 12-spec P0 `infra/host/web_e2e.sh` run: 140 passed, 3 existing conditional skips. The new progress regression passed, including reload.
- `pnpm security:check`: cargo-deny and Trivy passed.
- Agent Notes validator: 84 valid notes; scripts unit tests: 9 passed; final diff check clean. `pr-plan.sh` run with the installed Python 3.13.

An earlier full Rust run hit an unchanged connector-supervisor stop timing test. Twelve focused and twenty whole-supervisor repetitions on public main passed; the final unchanged full-workspace rerun also passed. No test was disabled or weakened, and this is not claimed as proof that the existing timing race is resolved. Logs: `/tmp/choruz-binding-workspace-final.log`, `choruz-binding-clippy-final.log`, `choruz-binding-e2e-final.log`, `choruz-binding-{red,retry-red,writer-red}.log` on the author host.

## Risk

Binding progress is now a real projection of active sessions rather than a permanently idle placeholder. Lock ordering, overlapping sessions, batches and recovery are covered. This does not add a single-turn identifier for multi-turn batches, change terminal transport or certify a particular external model provider's login/runtime availability.

AI-assisted implementation; the modified code and assertions were inspected, independently audited and tested.
