### PR TITLE
fix(ops): identify gateway readiness probes explicitly

### DIFF
--- a/.agents/notes/implemented/process/2026-09-06-verified-continuous-delivery.md
+++ b/.agents/notes/implemented/process/2026-09-06-verified-continuous-delivery.md
@@ -12,6 +12,8 @@ CI builds an immutable, commit-addressed archive and boots its API, pipeline and
 
 The designated repository's cloud-production environment owns the Cloudflare token. Gateway promotion checks storage migration state, pins a uniquely uploaded version and verifies the serving version and Online session route. Failure restores the exact prior version unless an intervening deployment makes rollback unsafe. Serialized, non-cancelling delivery and lifecycle records make the result diagnosable.
 
+Health probes identify themselves as `Choruz-CD/1.0`: Cloudflare can reject Python's default User-Agent with error 1010 before the Worker receives a request. Both readiness endpoints use the same explicit client identity; their status, version and response checks remain mandatory.
+
 Device updates are opt-in. One release helper owns manifest validation, atomic link replacement, managed-service restart and health-checked recovery. Writable state is outside release directories. Packaging does not activate code.
 
 ## Alternatives considered

--- a/infra/ops/deploy-gateway.py
+++ b/infra/ops/deploy-gateway.py
@@ -47,13 +47,14 @@ def probe(origin, version, timeout=60, require_metadata=True):
     deadline = time.monotonic() + timeout
     while True:
         try:
-            with urllib.request.urlopen(origin + "/healthz", timeout=5) as response:
+            headers = {"User-Agent": "Choruz-CD/1.0"}
+            with urllib.request.urlopen(urllib.request.Request(origin + "/healthz", headers=headers), timeout=5) as response:
                 health = json.load(response)
             if health.get("ok") is not True:
                 raise ValueError("gateway health is not ready")
             if require_metadata and (health.get("version") or {}).get("id") != version:
                 raise ValueError("gateway is serving a different release")
-            with urllib.request.urlopen(origin + "/v1/online/auth/get-session", timeout=5) as response:
+            with urllib.request.urlopen(urllib.request.Request(origin + "/v1/online/auth/get-session", headers=headers), timeout=5) as response:
                 if json.load(response) is not None:
                     raise ValueError("anonymous Online session response is invalid")
             return

--- a/infra/ops/tests/test_gateway_delivery.py
+++ b/infra/ops/tests/test_gateway_delivery.py
@@ -1,7 +1,9 @@
 import importlib.util
+from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 from pathlib import Path
 import tempfile
+import threading
 import unittest
 from unittest.mock import patch
 
@@ -11,6 +13,34 @@ spec.loader.exec_module(module)
 
 
 class GatewayDeliveryTests(unittest.TestCase):
+    def test_probe_identifies_itself_on_both_real_http_requests(self):
+        requests = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                requests.append((self.path, self.headers.get("User-Agent")))
+                if self.headers.get("User-Agent") != "Choruz-CD/1.0":
+                    self.send_error(403)
+                    return
+                payload = {"ok": True, "version": {"id": "right"}} if self.path == "/healthz" else None
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps(payload).encode())
+
+            def log_message(self, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        self.addCleanup(server.server_close)
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        self.addCleanup(thread.join)
+        self.addCleanup(server.shutdown)
+        module.probe(f"http://127.0.0.1:{server.server_port}", "right", timeout=0)
+        self.assertEqual(requests, [("/healthz", "Choruz-CD/1.0"),
+                                    ("/v1/online/auth/get-session", "Choruz-CD/1.0")])
+
     def setUp(self):
         self.temp = tempfile.TemporaryDirectory(prefix="choruz-cd-test-")
         self.addCleanup(self.temp.cleanup)


### PR DESCRIPTION
## Type

- [x] `bugfix`
- [x] `ci` / `build` / `deps`

## Agent Note

Updates `.agents/notes/implemented/process/2026-09-06-verified-continuous-delivery.md`.

## Summary

Identify gateway readiness requests as `Choruz-CD/1.0`. Cloudflare rejects Python's default client identity with HTTP 403 / 1010 before the Worker receives it. Both health and anonymous Online-session checks retain their existing validation. No security policy or token permissions are changed.

## Tests

New real-loopback HTTP regression exercises the production probe and rejects a missing identity on either endpoint. Verified red before the fix (HTTP 403), green after. The server owns a port-zero listener and shuts down, joins and closes during cleanup.

## Ran locally

- `pnpm ops:check`: 11 tests and ops templates/selectors passed.
- Live production helper probe: both health and anonymous Online session endpoints passed (read-only).
- Agent Notes: 88 conform; scripts test suite: 9 pass.
- PR selector against public main: ops/security/notes.
- `git diff --check`: clean.
- Independent GPT-5.6 Terra audit PASS and public-tree equivalence re-audit PASS. Patch SHA256: `195136f9d6dbf7d1e654ac439c0ad2ecd40e2f84484354f969a67c7258245f05`; tree `76983e3942debe8c10d20c6e156f58173ab414da`. Same tested patch as upstream.
- Simplify: retained direct HTTP requests and shared header owner; no additional safe simplification warranted.

## Risk

The local production check is not a claim of a completed rollout. Production CD will run from the designated private repository after its successful main CI; this public repository has no cloud deployment secrets or enablement flag. Public PR must pass its own required CI before merge.

The preceding public main run failed an unrelated existing Online E2E assertion on duplicate agent delivery. That failure is not bypassed or represented as green by this sync; this patch does not modify Online behavior.

AI-assisted implementation; changed lines reviewed and evidence verified.
